### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,13 @@ EMCC_OPTIONS = \
 
 BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o libsass/lib/libsass.a
 
+# Build webassembly version with JS loader glue code
 dist/binding.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
-	emcc -O2 -o $@ $(BINDING_SOURCES) $(EMCC_OPTIONS)
+	emcc -O2 -o $@ $(BINDING_SOURCES) -s WASM=1 $(EMCC_OPTIONS)
+
+# Build a more compatible and portable pure asmjs version
+dist/binding.asm.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
+	emcc -O2 -o $@ $(BINDING_SOURCES) -s WASM=0 $(EMCC_OPTIONS)
 
 dist/version.js: dist/binding.js
 	node -e "console.log('exports.libsass = \"' + require('./dist/binding').sassVersion() + '\"')" > $@

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,19 @@ LIBSASS_VERSION = 3.5.5
 CXXFLAGS = -Wall -O2 -std=c++17 -I libsass/include $(EXTRA_CXXFLAGS)
 
 EMCC_OPTIONS = \
+	--js-opts 2 \
+	--llvm-lto 1 \
+	-Wno-almost-asm \
 	-s ENVIRONMENT=node \
 	-s NODERAWFS=1 \
+	-s ASSERTIONS=0 \
+	-s STANDALONE_WASM=0 \
+	-s WASM_OBJECT_FILES=0 \
 	-s DISABLE_EXCEPTION_CATCHING=0 \
 	-s NODEJS_CATCH_EXIT=0 \
 	-s WASM_ASYNC_COMPILATION=0 \
 	-s ALLOW_MEMORY_GROWTH=1 \
+	-s MALLOC=dlmalloc \
 	--bind \
 	--js-library src/workaround8806.js
 # `--js-library workaround8806.js` must be AFTER `--bind` to override it!

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ all: dist/binding.js dist/version.js
 LIBSASS_VERSION ?= 3.5.5
 # It also works with 3.6.0 but sass-spec isn't compatible with 3.6.0 yet.
 
-CXXFLAGS = -Wall -O2 -std=c++17 -I libsass/include $(EXTRA_CXXFLAGS)
+LIBSASS_DIRECTORY ?= libsass
+
+CXXFLAGS = -Wall -O2 -std=c++17 -I $(LIBSASS_DIRECTORY)/include $(EXTRA_CXXFLAGS)
 
 EMCC_OPTIONS = \
 	--js-opts 2 \
@@ -32,7 +34,7 @@ EMCC_OPTIONS = \
 #EMCC_OPTIONS += -s DYNAMIC_EXECUTION=0 --profiling
 #EMCC_OPTIONS += --closure 1
 
-BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o libsass/lib/libsass.a
+BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o $(LIBSASS_DIRECTORY)/lib/libsass.a
 
 # Build webassembly version with JS loader glue code
 dist/binding.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
@@ -52,18 +54,18 @@ dist/entrypoint.o: src/functions.h src/importers.h
 dist/functions.o: src/functions.h
 dist/importers.o: src/importers.h
 
-libsass/lib/libsass.a: libsass
-	$(MAKE) -C libsass lib/libsass.a
+$(LIBSASS_DIRECTORY)/lib/libsass.a: libsass
+	$(MAKE) -C $(LIBSASS_DIRECTORY) lib/libsass.a
 
-libsass:
-	git -c advice.detachedHead=false clone https://github.com/sass/libsass -b $(LIBSASS_VERSION)
+$(LIBSASS_DIRECTORY):
+	git -c advice.detachedHead=false clone https://github.com/sass/libsass -b $(LIBSASS_VERSION) $(LIBSASS_DIRECTORY)
 
 dist:
 	mkdir dist
 
-clean:
+clean: $(LIBSASS_DIRECTORY)
 	-rm -rf dist
-	[ -d libsass ] && $(MAKE) -C libsass clean
+	$(MAKE) -C $(LIBSASS_DIRECTORY) clean
 
 veryclean:
 	-rm -rf dist libsass

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 all: dist/binding.js dist/version.js
 
-LIBSASS_VERSION = 3.5.5
+LIBSASS_VERSION ?= 3.5.5
 # It also works with 3.6.0 but sass-spec isn't compatible with 3.6.0 yet.
 
 CXXFLAGS = -Wall -O2 -std=c++17 -I libsass/include $(EXTRA_CXXFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-all: dist/binding.js dist/binding.wasm dist/version.js
+all: dist/binding.js dist/version.js
 
 LIBSASS_VERSION = 3.5.5
 # It also works with 3.6.0 but sass-spec isn't compatible with 3.6.0 yet.
@@ -27,7 +27,7 @@ EMCC_OPTIONS = \
 
 BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o libsass/lib/libsass.a
 
-dist/binding.js dist/binding.wasm: $(BINDING_SOURCES) src/workaround8806.js Makefile
+dist/binding.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
 	emcc -O2 -o $@ $(BINDING_SOURCES) $(EMCC_OPTIONS)
 
 dist/version.js: dist/binding.js dist/binding.wasm

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o libsass/li
 dist/binding.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
 	emcc -O2 -o $@ $(BINDING_SOURCES) $(EMCC_OPTIONS)
 
-dist/version.js: dist/binding.js dist/binding.wasm
-	node -e 'console.log("exports.libsass = %j;", require("./dist/binding").sassVersion())' > $@
+dist/version.js: dist/binding.js
+	node -e "console.log('exports.libsass = \"' + require('./dist/binding').sassVersion() + '\"')" > $@
 
 dist/%.o: src/%.cpp | dist libsass
 	$(CXX) $(CXXFLAGS) -c -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LIBSASS_VERSION ?= 3.5.5
 
 LIBSASS_DIRECTORY ?= libsass
 
-CXXFLAGS = -Wall -O2 -std=c++17 -I $(LIBSASS_DIRECTORY)/include $(EXTRA_CXXFLAGS)
+CXXFLAGS = -Wall -O3 -std=c++17 -I $(LIBSASS_DIRECTORY)/include $(EXTRA_CXXFLAGS)
 
 EMCC_OPTIONS = \
 	--js-opts 2 \
@@ -38,11 +38,11 @@ BINDING_SOURCES = dist/entrypoint.o dist/functions.o dist/importers.o $(LIBSASS_
 
 # Build webassembly version with JS loader glue code
 dist/binding.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
-	emcc -O2 -o $@ $(BINDING_SOURCES) -s WASM=1 $(EMCC_OPTIONS)
+	emcc -O3 -o $@ $(BINDING_SOURCES) -s WASM=1 $(EMCC_OPTIONS)
 
 # Build a more compatible and portable pure asmjs version
 dist/binding.asm.js: $(BINDING_SOURCES) src/workaround8806.js Makefile
-	emcc -O2 -o $@ $(BINDING_SOURCES) -s WASM=0 $(EMCC_OPTIONS)
+	emcc -O3 -o $@ $(BINDING_SOURCES) -s WASM=0 $(EMCC_OPTIONS)
 
 dist/version.js: dist/binding.js
 	node -e "console.log('exports.libsass = \"' + require('./dist/binding').sassVersion() + '\"')" > $@


### PR DESCRIPTION
Hi @TomiBelan, first thanks for the initial effort to get libsass to webassembly.
It seems with `NODERAWFS` this seems finally feasible. Made some experiments
yesterday, and wanted to contribute back what I found.

Please try it out, I only tested it on windows!

Given the small size and completeness of your work I'm even considering to
completely upstream this to libsass at some point (if that would be ok with you).

There are still a few open points though. I have tested the pure asmjs version and
it seems compatible even with node 4.9.1, although only in synchronised mode.
Your approach with (web) workers seems most portable going forward, but lacks
backward compatibility (AFAICT it works with node 10.5+ and --experimental-worker).

None the less it might be better to just fall back to sync mode in case workers aren't
available? Currently leaning in this direction to transparently support all possible node
versions with adaptive improvements if they are available. But I don't know all the 
implications if we unexpectedly block the main thread, although I would hope it
only means longer compile time and not breaking anything!? 

I will probably push another pull request soon with some backward compatibility stuff, e.g.:

```js
var binding = (typeof WebAssembly !== "object")
  ? require('../dist/binding.asm')
  : require('../dist/binding');
```

```js
  try {
    asyncRunner = require('./asyncRunner');
  }
  catch(err) {
    try {
      var result = exports.renderSync(options);
      callback.call(context.thisObj, null, result)
    }
    catch (err) {
      callback.call(context.thisObj, err)
    }
    return;
  }
  return asyncRunner(...);
```

There is currently an issue with libsass and emscripten when NODERAWFS is used:
https://github.com/emscripten-core/emscripten/issues/9628

I'm testing it with my latest refactoring branch against:
https://github.com/sass/sass/files/3587253/bolt-bench.zip

The numbers are not super exciting, but also not bad.
- node-sass-wasm with webassembly: ~4s
- node-sass-wasm with asmjs: 6-8s
- perl-libsass: 1.3s
- node-sass: 1.4s
- native dart-sass: 9.7s
- sassc fully optimized:  0.8s

Overall around 3 to 4 times slower than native libsass.

Thank you and have a nice day!